### PR TITLE
1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,8 @@
 venv/*
 *.pyc
 *.cache
-
 */rpms/*
-
 Dockerfile_*-integration-test
-
 gitea-*
-
 TODO
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ install:
 script:
   - ./init.sh
   - . venv/bin/activate
-  - fab build_rpms:gitea_version=1.2
+  - fab build_rpms:gitea_version=1.3

--- a/README.md
+++ b/README.md
@@ -76,10 +76,14 @@ fab build_rpms:gitea_version=1.2,spec_template=/builds/gitea-1.2-2
 ## Building the next release
 Sweet!  We want to build a new RPM for the gitea RPM.  Let's say we are upgrading from `1.2` to `1.3`.  All we need to do is the following.
 
+The best method would be to create a new branch, do the the following changes and then tag the release instead of polluting your repo with `builds/gitea-<version>` stuff.
+
 * We create a new file in `builds/gitea-1.3-1`
 * **[OPTIONAL]** adjust the RPM specfile template as needed.
 * Build the RPMs
 
+
+NOTE: this is optional and sould only be used when building a patch release. A major release should be done in a new branch and then tagged.
 ```
 cat > builds/gitea-1.3-1 << EOF
 {
@@ -90,6 +94,10 @@ EOF
 
 fab build_rpms:gitea_version=1.3,spec_template=/builds/gitea-1.3-1
 ```
+
+* Ensure the tests for each operating system are updated
+* Ensure the the [.travis.yml](.travis.yml) is updated with the new version
+* Ensure the fabfile.py files are updated with the right version
 
 
 ## Available JSON parameters for the RPM spec file

--- a/builds/fabfile.py
+++ b/builds/fabfile.py
@@ -3,7 +3,7 @@ import os
 import testinfra
 
 
-from fabric.api import *
+from fabric.api import *  # noqa: F403
 from jinja2 import Template
 
 GITEA_REMOTE_DIR = '/opt/gitea'
@@ -20,7 +20,7 @@ GITEA_HTTP_PORT = GITEA_PORT
 
 DEFAULT_SPEC_DATA = {
     'package_name': 'gitea',
-    'package_version': '1.2',
+    'package_version': '1.3',
     'package_release': '1',
 
     'distro': 'linux',

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,9 +1,8 @@
 import hashlib
 import os
 import requests
-import sys
 
-from fabric.api import *
+from fabric.api import *  # noqa: F403
 from fabric.utils import error
 from os import environ as ENV
 
@@ -94,7 +93,7 @@ def build_rpm(distro='centos6', spec_template=''):
 
     args = []
     if spec_template:
-        args.append('spec_template=%s' %(spec_template))
+        args.append('spec_template=%s' % (spec_template))
 
     if args:
         args = ','.join(args)
@@ -115,6 +114,9 @@ def build_rpms(gitea_version, gitea_distro='linux', gitea_arch='amd64', spec_tem
 
     download_gitea_binary(version=gitea_version, distro=gitea_distro, arch=gitea_arch)
 
+    build(distro='centos6')
+    build(distro='centos7')
+
     if build_git:
         build_git18(distro='centos6')
 
@@ -123,6 +125,7 @@ def build_rpms(gitea_version, gitea_distro='linux', gitea_arch='amd64', spec_tem
 
     if run_tests:
         test()
+
 
 @task
 def clean():
@@ -134,6 +137,7 @@ def clean():
     for x in SUPPORTED_DISTROS:
         local('docker rmi gitea-rpmbuild/{} || :'.format(x))
         local('docker rmi gitea-{}-integration-test || :'.format(x))
+
 
 @task
 def download_gitea_binary(version, distro='linux', arch='amd64'):
@@ -148,8 +152,8 @@ def download_gitea_binary(version, distro='linux', arch='amd64'):
     local('mkdir -p {basedir}/builds/bits'.format(basedir=BASEDIR))
 
     bin_fname = "{basedir}/builds/bits/{filename}".format(basedir=BASEDIR,
-                                                     filename='gitea-{}-{}-{}'.format(version, distro, arch)
-                                                     )
+                                                          filename='gitea-{}-{}-{}'.format(version, distro, arch)
+                                                          )
     sha256_fname = bin_fname + '.sha256'
 
     binary_sha256 = GET_HTTP(url_sha256, sha256_fname)
@@ -158,7 +162,7 @@ def download_gitea_binary(version, distro='linux', arch='amd64'):
     if validate_checksum(expected_cksum, bin_fname):
         return
 
-    binary = GET_HTTP(url, bin_fname)
+    GET_HTTP(url, bin_fname)
     if validate_checksum(expected_cksum, bin_fname):
         return
 
@@ -172,7 +176,7 @@ def test(debug=False):
     if debug:
         args += '--pdb'
 
-    local('testinfra -vs {}'.format(args))
+    local('py.test -vs {}'.format(args))
 
 
 @task

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-Fabric
-Jinja2
-paramiko
-requests
-testinfra
+Fabric==1.14.0
+hacking==1.0.0
+Jinja2==2.10
+paramiko==2.4.0
+requests==2.18.4
+testinfra==1.10.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[flake8]
+ignore = H101,H102,E241
+
+max-line-length = 150

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,11 +6,10 @@ import os
 import pytest
 import sys
 import testinfra
-import threading
 import time
 
 # When patching testinfra just make sure this is after you import testsinfra
-from tests.patches import *
+from tests.patches import *  # noqa: F403
 from six.moves import urllib
 
 
@@ -22,13 +21,12 @@ local = testinfra.get_host('local://').check_output
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 os.chdir(TEST_DIR)
 
+INSTALL_GITEA_VERSION = 'gitea-1.3'
 
-INSTALL_GITEA_VERSION='gitea-1.2'
-
-GITEA_VERSION='1.2.0'
+GITEA_VERSION = '1.3.1'
 
 
-BASE_DIR= os.path.realpath(os.path.join(TEST_DIR, os.path.pardir))
+BASE_DIR = os.path.realpath(os.path.join(TEST_DIR, os.path.pardir))
 BUILDS_DIR = os.path.realpath(os.path.join(BASE_DIR, 'builds'))
 
 
@@ -36,8 +34,8 @@ SUT_CENTOS6 = 'gitea-centos6-integration-test'
 SUT_CENTOS7 = 'gitea-centos7-integration-test'
 
 DOCKER_IMAGES = [
-        SUT_CENTOS6,
-        SUT_CENTOS7,
+    SUT_CENTOS6,
+    SUT_CENTOS7,
 ]
 
 TEST_DOCKERFILE = '''

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,19 +220,19 @@ initialize_container_fixtures()
 def build_ssh_config(port, docker_id=None, user='root'):
     filename = os.path.join(TEST_DIR, 'ssh_config')
     if docker_id:
-        filename = os.path.join(TEST_DIR, 'ssh_config.%s' %(docker_id))
+        filename = os.path.join(TEST_DIR, 'ssh_config.%s' % (docker_id))
 
     items = [
         'Host *',
         'StrictHostKeyChecking no',
         'UserKnownHostsFile /dev/null',
-        'IdentityFile %s' %(os.path.join(TEST_DIR, 'id_rsa')),
-        'User %s' %(user),
-        'Port %s' %(port),
+        'IdentityFile %s' % (os.path.join(TEST_DIR, 'id_rsa')),
+        'User %s' % (user),
+        'Port %s' % (port),
     ]
     with open(filename, 'w') as fd:
         fd.write('\n'.join(items))
-    os.chmod(filename, 384) # 0600
+    os.chmod(filename, 384)  # 0600
 
     return filename
 

--- a/tests/patches.py
+++ b/tests/patches.py
@@ -1,5 +1,6 @@
 import testinfra.modules
-from testinfra.modules.service import *
+from testinfra.modules.service import *  # noqa: H303
+
 
 class PatchedService(Service):
 

--- a/tests/test_centos6.py
+++ b/tests/test_centos6.py
@@ -1,13 +1,10 @@
 import os
 import pytest
 
-from glob import glob
-
-from tests.conftest import get_os_release
-from tests.conftest import TEST_DIR
-from tests.conftest import INSTALL_GITEA_VERSION
 from tests.conftest import GITEA_VERSION
+from tests.conftest import INSTALL_GITEA_VERSION
 from tests.conftest import SUT_CENTOS6
+from tests.conftest import TEST_DIR
 
 
 os.chdir(TEST_DIR)
@@ -18,7 +15,7 @@ def test_the_gitea_rpm_installs_cleanly(host, install_rpm):
     install_rpm(host=host, name=['git', INSTALL_GITEA_VERSION])
 
     assert host.run('rpm -q git --qf "%{VERSION}"').stdout.startswith('1.8')
-    assert host.run('rpm -q gitea --qf "%{VERSION}"').stdout.startswith('1.2')
+    assert host.run('rpm -q gitea --qf "%{VERSION}"').stdout.startswith('1.3')
 
 
 @pytest.mark.docker_images(SUT_CENTOS6)
@@ -46,17 +43,17 @@ def test_opt_gitea_exists(host):
     assert root_dir.is_directory
     assert root_dir.user == 'gitea'
     assert root_dir.group == 'gitea'
-    assert root_dir.mode == 448 # 0700
+    assert root_dir.mode == 448  # 0700
 
     assert host.file('/opt/gitea/gitea').exists
     assert host.file('/opt/gitea/gitea').user == 'root'
     assert host.file('/opt/gitea/gitea').group == 'gitea'
-    assert host.file('/opt/gitea/gitea').mode == 365 # 0555
+    assert host.file('/opt/gitea/gitea').mode == 365  # 0555
 
     assert host.file('/opt/gitea/gitea-adm').exists
     assert host.file('/opt/gitea/gitea-adm').user == 'root'
     assert host.file('/opt/gitea/gitea-adm').group == 'root'
-    assert host.file('/opt/gitea/gitea-adm').mode == 493 # 0755
+    assert host.file('/opt/gitea/gitea-adm').mode == 493  # 0755
 
 
 @pytest.mark.docker_images(SUT_CENTOS6)
@@ -66,14 +63,14 @@ def test_etc_gitea_conf_exists(host):
     assert etc_gitea.is_directory
     assert etc_gitea.user == 'root'
     assert etc_gitea.group == 'gitea'
-    assert etc_gitea.mode == 509 # 0775
+    assert etc_gitea.mode == 509  # 0775
 
     gitea_conf = host.file('/etc/gitea/gitea.conf')
 
     assert gitea_conf.exists
     assert gitea_conf.user == 'root'
     assert gitea_conf.group == 'gitea'
-    assert gitea_conf.mode == 436 # 0664
+    assert gitea_conf.mode == 436  # 0664
 
     # test custom content
     assert gitea_conf.contains('RUN_USER = gitea')
@@ -91,7 +88,7 @@ def test_etc_default_gitea_exists(host):
     assert etc_default_gitea.exists
     assert etc_default_gitea.user == 'root'
     assert etc_default_gitea.group == 'gitea'
-    assert etc_default_gitea.mode == 436 # 0664
+    assert etc_default_gitea.mode == 436  # 0664
 
     # test file content
     assert etc_default_gitea.contains('GITEA_RUN_USER="gitea"')
@@ -119,7 +116,7 @@ def test_etc_initd_gitea_exists(host):
     assert initd_gitea.exists
     assert initd_gitea.user == 'root'
     assert initd_gitea.group == 'root'
-    assert initd_gitea.mode == 493 # 0755
+    assert initd_gitea.mode == 493  # 0755
 
 
 @pytest.mark.docker_images(SUT_CENTOS6)
@@ -129,7 +126,7 @@ def test_var_run_gitea_exists(host):
     assert var_run.exists
     assert var_run.user == 'root'
     assert var_run.group == 'gitea'
-    assert var_run.mode == 509 # 0775
+    assert var_run.mode == 509  # 0775
 
 
 @pytest.mark.docker_images(SUT_CENTOS6)
@@ -139,7 +136,7 @@ def test_var_log_gitea_exists(host):
     assert var_run.exists
     assert var_run.user == 'root'
     assert var_run.group == 'gitea'
-    assert var_run.mode == 509 # 0775
+    assert var_run.mode == 509  # 0775
 
 
 @pytest.mark.docker_images(SUT_CENTOS6)
@@ -198,12 +195,12 @@ def test_gitea_service_script_can_create_cacerts_into_current_working_directory_
     assert host.file('key.pem').exists
     assert host.file('key.pem').user == 'root'
     assert host.file('key.pem').group == 'root'
-    assert host.file('key.pem').mode == 384 # 0600
+    assert host.file('key.pem').mode == 384  # 0600
 
     assert host.file('cert.pem').exists
     assert host.file('cert.pem').user == 'root'
     assert host.file('cert.pem').group == 'root'
-    assert host.file('cert.pem').mode == 420 # 0644
+    assert host.file('cert.pem').mode == 420  # 0644
 
 
 @pytest.mark.docker_images(SUT_CENTOS6)

--- a/tests/test_centos7.py
+++ b/tests/test_centos7.py
@@ -1,13 +1,10 @@
 import os
 import pytest
 
-from glob import glob
-
-from tests.conftest import get_os_release
-from tests.conftest import TEST_DIR
-from tests.conftest import INSTALL_GITEA_VERSION
 from tests.conftest import GITEA_VERSION
+from tests.conftest import INSTALL_GITEA_VERSION
 from tests.conftest import SUT_CENTOS7
+from tests.conftest import TEST_DIR
 
 
 os.chdir(TEST_DIR)
@@ -18,7 +15,7 @@ def test_the_gitea_rpm_installs_cleanly(host, install_rpm):
     install_rpm(host=host, name=['git', INSTALL_GITEA_VERSION])
 
     assert host.run('rpm -q git --qf "%{VERSION}"').stdout.startswith('1.8')
-    assert host.run('rpm -q gitea --qf "%{VERSION}"').stdout.startswith('1.2')
+    assert host.run('rpm -q gitea --qf "%{VERSION}"').stdout.startswith('1.3')
 
 
 @pytest.mark.docker_images(SUT_CENTOS7)
@@ -49,17 +46,17 @@ def test_opt_gitea_exists(host):
     assert root_dir.is_directory
     assert root_dir.user == 'gitea'
     assert root_dir.group == 'gitea'
-    assert root_dir.mode == 448 # 0700
+    assert root_dir.mode == 448  # 0700
 
     assert host.file('/opt/gitea/gitea').exists
     assert host.file('/opt/gitea/gitea').user == 'root'
     assert host.file('/opt/gitea/gitea').group == 'gitea'
-    assert host.file('/opt/gitea/gitea').mode == 365 # 0555
+    assert host.file('/opt/gitea/gitea').mode == 365  # 0555
 
     assert host.file('/opt/gitea/gitea-adm').exists
     assert host.file('/opt/gitea/gitea-adm').user == 'root'
     assert host.file('/opt/gitea/gitea-adm').group == 'root'
-    assert host.file('/opt/gitea/gitea-adm').mode == 493 # 0755
+    assert host.file('/opt/gitea/gitea-adm').mode == 493  # 0755
 
 
 @pytest.mark.docker_images(SUT_CENTOS7)
@@ -69,14 +66,14 @@ def test_etc_gitea_gitea_conf_exists(host):
     assert etc_gitea.is_directory
     assert etc_gitea.user == 'root'
     assert etc_gitea.group == 'gitea'
-    assert etc_gitea.mode == 509 # 0775
+    assert etc_gitea.mode == 509  # 0775
 
     gitea_conf = host.file('/etc/gitea/gitea.conf')
 
     assert gitea_conf.exists
     assert gitea_conf.user == 'root'
     assert gitea_conf.group == 'gitea'
-    assert gitea_conf.mode == 436 # 0664
+    assert gitea_conf.mode == 436  # 0664
 
     # test custom content
     assert gitea_conf.contains('RUN_USER = gitea')
@@ -93,7 +90,7 @@ def test_var_run_gitea_exists(host):
     assert var_run.exists
     assert var_run.user == 'root'
     assert var_run.group == 'gitea'
-    assert var_run.mode == 509 # 0775
+    assert var_run.mode == 509  # 0775
 
 
 @pytest.mark.docker_images(SUT_CENTOS7)
@@ -102,7 +99,7 @@ def test_var_log_gitea_exists(host):
     assert var_run.exists
     assert var_run.user == 'root'
     assert var_run.group == 'gitea'
-    assert var_run.mode == 509 # 0775
+    assert var_run.mode == 509  # 0775
 
 
 @pytest.mark.docker_images(SUT_CENTOS7)
@@ -112,7 +109,7 @@ def test_etc_default_gitea_exists(host):
     assert etc_default_gitea.exists
     assert etc_default_gitea.user == 'root'
     assert etc_default_gitea.group == 'gitea'
-    assert etc_default_gitea.mode == 436 # 0664
+    assert etc_default_gitea.mode == 436  # 0664
 
     # test file content
     assert etc_default_gitea.contains('GITEA_RUN_USER="gitea"')
@@ -165,12 +162,12 @@ def test_gitea_service_script_can_create_cacerts_into_current_working_directory_
     assert host.file('key.pem').exists
     assert host.file('key.pem').user == 'root'
     assert host.file('key.pem').group == 'root'
-    assert host.file('key.pem').mode == 384 # 0600
+    assert host.file('key.pem').mode == 384  # 0600
 
     assert host.file('cert.pem').exists
     assert host.file('cert.pem').user == 'root'
     assert host.file('cert.pem').group == 'root'
-    assert host.file('cert.pem').mode == 420 # 0644
+    assert host.file('cert.pem').mode == 420  # 0644
 
 
 @pytest.mark.docker_images(SUT_CENTOS7)
@@ -181,7 +178,7 @@ def test_systemd_service_script_exists(host):
     assert gitea_systemd.is_file
     assert gitea_systemd.user == 'root'
     assert gitea_systemd.group == 'root'
-    assert gitea_systemd.mode == 420 # 0644
+    assert gitea_systemd.mode == 420  # 0644
 
     # Assert custom content
     assert gitea_systemd.contains('EnvironmentFile=/etc/default/gitea')
@@ -202,7 +199,7 @@ def test_gitea_service_will_startup_through_systemd(host, wait_for_svc):
     assert host.service('gitea').is_running is False
     assert host.service('gitea').is_enabled is False
 
-    result =  host.run('systemctl start gitea')
+    result = host.run('systemctl start gitea')
     wait_for_svc(host, 'start', timeout=5)
     assert result.rc == 0
 

--- a/tests/test_patches.py
+++ b/tests/test_patches.py
@@ -1,7 +1,7 @@
 import pytest
 
 from tests.conftest import SUT_CENTOS6
-from tests.conftest import SUT_CENTOS7
+
 
 @pytest.mark.docker_images(SUT_CENTOS6)
 def test_we_patched_the_service_module_to_SysvService_on_centos6(host):

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+# For more information about tox, see https://tox.readthedocs.io/en/latest/
+[tox]
+envlist=py27,flake8
+skipsdist=True
+
+[testenv]
+setenv=
+  PYTHONPATH={toxinidir}
+deps=
+ -rrequirements.txt
+commands=py.test {posargs:-vv tests}
+# usedevelop = True
+passenv=HOME DOCKER_CERT_PATH DOCKER_HOST DOCKER_TLS_VERIFY
+
+[testenv:flake8]
+skip_install=true
+commands=flake8 tests


### PR DESCRIPTION
CHANGELOG:
==========
https://github.com/go-gitea/gitea/releases/tag/v1.3.1

* Added tox integration for easier local testing and to better simulate why Travis CI might do
* Bunch of PEP8 code fixes, no change in functionality
* Bumped gitea RPM version to 1.3
* README updates to make major release patching a little easier to understand.  This still needs a lot more work.
* Fixes with fabric tasks to actually do what the README states.
* Version pinned the requirements.txt file for all required libraries needed to build the gitea RPM.